### PR TITLE
Fix bug in training command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,12 @@ DiT models, but it can be easily modified to support other types of conditioning
 To launch DiT-XL/2 (256x256) training with `1` GPUs on one node:
 
 ```bash
-accelerate launch --mixed_precision fp16 train.py --model DiT-XL/2 --features-path /path/to/store/features
+accelerate launch --mixed_precision fp16 train.py --model DiT-XL/2 --feature-path /path/to/store/features
 ```
 
 To launch DiT-XL/2 (256x256) training with `N` GPUs on one node:
 ```bash
-accelerate launch --multi_gpu --num_processes N --mixed_precision fp16 train.py --model DiT-XL/2 --features-path /path/to/store/features
+accelerate launch --multi_gpu --num_processes N --mixed_precision fp16 train.py --model DiT-XL/2 --feature-path /path/to/store/features
 ```
 
 Alternatively, you have the option to extract and train the scripts located in the folder [training options](train_options).


### PR DESCRIPTION
the argument name in `train.py` is `--feature-path` but not `--features-path`

https://github.com/chuanyangjin/fast-DiT/blob/1a8ecce58f346f877749f2dc67cdb190d295e4dc/train.py#L251