### PR TITLE
[fix] align loss scale to DiT official impl

### DIFF
--- a/train.py
+++ b/train.py
@@ -215,9 +215,12 @@ def main(args):
                 torch.cuda.synchronize()
                 end_time = time()
                 steps_per_sec = log_steps / (end_time - start_time)
-                # Reduce loss history over all processes:
                 avg_loss = torch.tensor(running_loss / log_steps, device=device)
                 avg_loss = avg_loss.item() / accelerator.num_processes
+
+                avg_loss = torch.tensor(avg_loss, device=accelerator.device)
+                avg_loss = accelerator.reduce(avg_loss, reduction="sum")
+
                 if accelerator.is_main_process:
                     logger.info(f"(step={train_steps:07d}) Train Loss: {avg_loss:.4f}, Train Steps/Sec: {steps_per_sec:.2f}")
                 # Reset monitoring variables:


### PR DESCRIPTION
## Summary

This PR aligns the print loss behavior with the official DiT implementation.

## Details

- Uses accelerate.reduce to properly aggregate the loss across all processes when using distributed training, ensuring that the reported loss matches the official DiT implementation.

## Related Issue

Resolves [#16](https://github.com/chuanyangjin/fast-DiT/issues/16)
