### PR TITLE
[Add Features] Better ImageNet Feature Extraction (multi-GPU, batch size)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ python sample.py --model DiT-L/4 --image-size 256 --ckpt /path/to/model.pt
 
 ## Training
 ### Preparation Before Training
-To extract ImageNet features with `1` GPUs on one node:
+To extract ImageNet features with `N` GPUs on one node:
 
 ```bash
-torchrun --nnodes=1 --nproc_per_node=1 extract_features.py --model DiT-XL/2 --data-path /path/to/imagenet/train --features-path /path/to/store/features
+torchrun --nnodes=1 --nproc_per_node=N extract_features.py --model DiT-XL/2 --data-path /path/to/imagenet/train --features-path /path/to/store/features --global-batch-size=256
 ```
 
 ### Training DiT

--- a/environment.yml
+++ b/environment.yml
@@ -11,3 +11,4 @@ dependencies:
     - timm
     - diffusers
     - accelerate
+    - tqdm

--- a/extract_features.py
+++ b/extract_features.py
@@ -133,7 +133,7 @@ def main(args):
     # Create model:
     assert args.image_size % 8 == 0, "Image size must be divisible by 8 (for the VAE encoder)."
     latent_size = args.image_size // 8
-    vae = AutoencoderKL.from_pretrained(/aiarena/gpfs/fast-DiT-lavinal712/extract_features.py).to(device)
+    vae = AutoencoderKL.from_pretrained(f"stabilityai/sd-vae-ft-{args.vae}").to(device)
 
     # Setup data:
     local_batch_size = args.global_batch_size // dist.get_world_size()

--- a/extract_features.py
+++ b/extract_features.py
@@ -133,7 +133,7 @@ def main(args):
     # Create model:
     assert args.image_size % 8 == 0, "Image size must be divisible by 8 (for the VAE encoder)."
     latent_size = args.image_size // 8
-    vae = AutoencoderKL.from_pretrained("/aiarena/group/gmgroup/hongyq/models/stabilityai/sd-vae-ft-ema").to(device)
+    vae = AutoencoderKL.from_pretrained(/aiarena/gpfs/fast-DiT-lavinal712/extract_features.py).to(device)
 
     # Setup data:
     local_batch_size = args.global_batch_size // dist.get_world_size()

--- a/extract_features.py
+++ b/extract_features.py
@@ -26,6 +26,7 @@ from time import time
 import argparse
 import logging
 import os
+from tqdm import tqdm
 
 from models import DiT_models
 from diffusion import create_diffusion
@@ -132,9 +133,10 @@ def main(args):
     # Create model:
     assert args.image_size % 8 == 0, "Image size must be divisible by 8 (for the VAE encoder)."
     latent_size = args.image_size // 8
-    vae = AutoencoderKL.from_pretrained(f"stabilityai/sd-vae-ft-{args.vae}").to(device)
+    vae = AutoencoderKL.from_pretrained("/aiarena/group/gmgroup/hongyq/models/stabilityai/sd-vae-ft-ema").to(device)
 
     # Setup data:
+    local_batch_size = args.global_batch_size // dist.get_world_size()
     transform = transforms.Compose([
         transforms.Lambda(lambda pil_image: center_crop_arr(pil_image, args.image_size)),
         transforms.RandomHorizontalFlip(),
@@ -151,33 +153,36 @@ def main(args):
     )
     loader = DataLoader(
         dataset,
-        batch_size = 1,
+        batch_size = local_batch_size,
         shuffle=False,
         sampler=sampler,
         num_workers=args.num_workers,
         pin_memory=True,
-        drop_last=True
+        drop_last=False
     )
 
     NUM_SAMPLES = len(sampler)
 
     train_steps = 0
-    for x, y in loader:
+    for x, y in tqdm(loader, total=len(loader), desc=f"Rank {rank}"):
         x = x.to(device)
         y = y.to(device)
         with torch.no_grad():
             # Map input images to latent space + normalize latents:
             x = vae.encode(x).latent_dist.sample().mul_(0.18215)
             
-        x = x.detach().cpu().numpy()    # (1, 4, 32, 32)
-        save_num = NUM_SAMPLES * rank + train_steps
-        np.save(f'{args.features_path}/imagenet256_features/{save_num}.npy', x)
-
-        y = y.detach().cpu().numpy()    # (1,)
-        np.save(f'{args.features_path}/imagenet256_labels/{save_num}.npy', y)
+        x = x.detach().cpu().numpy()    # (bs, 4, 32, 32)
+        y = y.detach().cpu().numpy()    # (bs,)
+        for i in range(x.shape[0]):
+            # save_num = NUM_SAMPLES * rank + train_steps * local_batch_size + i
+            save_num = train_steps * args.global_batch_size + dist.get_world_size() * i + rank
+            np.save(f'{args.features_path}/imagenet256_features/{save_num}.npy', np.expand_dims(x[i], axis=0))
+            np.save(f'{args.features_path}/imagenet256_labels/{save_num}.npy', np.expand_dims(y[i], axis=0))
             
         train_steps += 1
-        print(save_num)
+        # print(save_num)
+
+    cleanup()
 
 if __name__ == "__main__":
     # Default args here will train DiT-XL/2 with the hyperparameters we used in our paper (except training iters).


### PR DESCRIPTION
# What does this PR do?

1. Uses `tqdm` to provide more user-friendly progress output.
2. Supports multi-GPU extraction on a single node.
3. Supports custom batch sizes to accelerate feature extraction.
4. Fixed the DDP warning at termination caused by not calling `cleanup()`.

# Related Issue

This PR overlaps with the work done in https://github.com/chuanyangjin/fast-DiT/pull/19, but provides a more comprehensive and improved implementation.



